### PR TITLE
add strict mode to zip code rules

### DIFF
--- a/src/Rules/ZipCode.php
+++ b/src/Rules/ZipCode.php
@@ -27,7 +27,7 @@ class ZipCode implements Rule
         $regex = '/^\d{3}\-?\d{4}$/';
 
         // in strict mode, $value must include a hyphen
-        if ($this->parameters[0] == 'strict') {
+        if ($this->parameters['strict'] === true) {
           $regex = '/^\d{3}\-\d{4}$/';
         }
         return preg_match($regex, $value);

--- a/src/Rules/ZipCode.php
+++ b/src/Rules/ZipCode.php
@@ -30,7 +30,7 @@ class ZipCode implements Rule
 
         // in strict mode, $value must include a hyphen
         if ($this->parameters['strict'] === true) {
-          $regex = '/^\d{3}\-\d{4}$/';
+            $regex = '/^\d{3}\-\d{4}$/';
         }
         return preg_match($regex, $value);
     }

--- a/src/Rules/ZipCode.php
+++ b/src/Rules/ZipCode.php
@@ -6,7 +6,9 @@ use Illuminate\Contracts\Validation\Rule;
 
 class ZipCode implements Rule
 {
-    public $parameters;
+    public $parameters = [
+        'strict' => false
+    ];
 
     public function __construct($parameters = [])
     {

--- a/src/Rules/ZipCode.php
+++ b/src/Rules/ZipCode.php
@@ -6,6 +6,13 @@ use Illuminate\Contracts\Validation\Rule;
 
 class ZipCode implements Rule
 {
+    public $parameters;
+
+    public function __construct($parameters = [])
+    {
+        $this->parameters = $parameters;
+    }
+
     /**
      * Determine if the validation rule passes.
      *
@@ -18,6 +25,11 @@ class ZipCode implements Rule
     public function passes($attribute, $value)
     {
         $regex = '/^\d{3}\-?\d{4}$/';
+
+        // in strict mode, $value must include a hyphen
+        if ($this->parameters[0] == 'strict') {
+          $regex = '/^\d{3}\-\d{4}$/';
+        }
         return preg_match($regex, $value);
     }
 

--- a/src/Validators/ValiiValidator.php
+++ b/src/Validators/ValiiValidator.php
@@ -99,6 +99,12 @@ class ValiiValidator extends Validator
     public function validateZipCode(string $attribute, $value, array $parameters): bool
     {
         $regex = '/^\d{3}\-?\d{4}$/';
+
+        // in strict mode, $value must include a hyphen
+        if ($parameters[0] == 'strict') {
+          $regex = '/^\d{3}\-\d{4}$/';
+        }
+        
         return preg_match($regex, $value);
     }
 }

--- a/tests/Unit/Rules/ZipCodeTest.php
+++ b/tests/Unit/Rules/ZipCodeTest.php
@@ -14,7 +14,7 @@ class ZipCodeTest extends TestCase
     /**
      * 郵便番号のテスト
      *
-     * @dataProvider providerTel
+     * @dataProvider providerZipCode
      * @param $tel string テストデータ
      * @param mixed $expect
      */
@@ -35,15 +35,55 @@ class ZipCodeTest extends TestCase
     }
 
     /**
+     * 郵便番号のテスト
+     *
+     * @dataProvider providerZipCodeWithHyphen
+     * @param $tel string テストデータ
+     * @param mixed $expect
+     */
+    public function test_郵便番号チェック（ハイフンあり）($zipCode, $expect)
+    {
+        $rule = [
+            'name' => [
+                new ZipCode(['strict'])
+            ]
+        ];
+        $dataList = [];
+        $dataList['name'] = $zipCode;
+
+        $trans = $this->getTranslator();
+        $validator = new Validator($trans, $dataList, $rule);
+        $result = $validator->passes();
+        $this->assertEquals($expect, $result);
+    }
+
+    /**
      * テストデータ
      *
      * @return array
      */
-    public function providerTel(): array
+    public function providerZipCode(): array
     {
         return [
             '郵便番号' => ['123-4567', true],
             '郵便番号（ハイフンなし）' => ['1234567', true],
+            '郵便番号（数字8桁）' => ['12345678', false],
+            '郵便番号（数字6桁）' => ['123456', false],
+            '郵便番号（文字）' => ['abcdecf', false],
+            '郵便番号（全角）' => ['１２３４５６７', false],
+        ];
+    }
+
+    /**
+     * テストデータ(ハイフンあり)
+     *
+     * @return array
+     */
+    public function providerZipCodeWithHyphen(): array
+    {
+        return [
+            '郵便番号' => ['123-4567', true],
+            '郵便番号（ハイフンなし）' => ['1234567', false],
             '郵便番号（数字8桁）' => ['12345678', false],
             '郵便番号（数字6桁）' => ['123456', false],
             '郵便番号（文字）' => ['abcdecf', false],

--- a/tests/Unit/Rules/ZipCodeTest.php
+++ b/tests/Unit/Rules/ZipCodeTest.php
@@ -45,7 +45,7 @@ class ZipCodeTest extends TestCase
     {
         $rule = [
             'name' => [
-                new ZipCode(['strict'])
+                new ZipCode(['strict' => true])
             ]
         ];
         $dataList = [];


### PR DESCRIPTION
```
$rules = ['zip_code' => 'zip_code:strict'];
$input1 = ['zip_code' => '1234567'];
$input2 = ['zip_code' => '123-4567'];
Validator::make($input1, $rules)->passes(); // false
Validator::make($input2, $rules)->passes(); // true
```
