### PR TITLE
Add allow spaces mode in Katakana, HankakuKatakana, Hiragana

### DIFF
--- a/src/Validators/ValiiValidator.php
+++ b/src/Validators/ValiiValidator.php
@@ -61,6 +61,12 @@ class ValiiValidator extends Validator
     public function validateHankakuKatakana(string $attribute, $value, array $parameters): bool
     {
         $regex = '/^(?:\xEF\xBD[\xA6-\xBF]|\xEF\xBE[\x80-\x9F])*$/';
+
+        // in allow_spaces mode
+        if (isset($parameters[0]) && $parameters[0] == 'allow_spaces') {
+            $regex = '/^(?:\xEF\xBD[\xA6-\xBF]|\xEF\xBE[\x80-\x9F]|[ ])*$/';
+        }
+
         return preg_match($regex, $value);
     }
 
@@ -77,6 +83,12 @@ class ValiiValidator extends Validator
     public function validateHiragana(string $attribute, $value, array $parameters): bool
     {
         $regex = '/^(\xe3(\x81[\x81-\xbf]|\x82[\x80-\x93]|\x83\xbc))*$/';
+
+        // in allow_spaces mode
+        if (isset($parameters[0]) && $parameters[0] == 'allow_spaces') {
+            $regex = '/^(\xe3(\x81[\x81-\xbf]|\x82[\x80-\x93]|\x83\xbc)|[　 ])*$/';
+        }
+
         return preg_match($regex, $value);
     }
 
@@ -93,6 +105,12 @@ class ValiiValidator extends Validator
     public function validateKatakana(string $attribute, $value, array $parameters): bool
     {
         $regex = '/^(\xe3(\x82[\xa1-\xbf]|\x83[\x80-\xb6]|\x83\xbc|\x82\x9b|\x82\x9c))*$/';
+
+        // in allow_spaces mode
+        if (isset($parameters[0]) && $parameters[0] == 'allow_spaces') {
+            $regex = '/^(\xe3(\x82[\xa1-\xbf]|\x83[\x80-\xb6]|\x83\xbc|\x82\x9b|\x82\x9c)|[　 ])*$/';
+        }
+
         return preg_match($regex, $value);
     }
 
@@ -109,6 +127,7 @@ class ValiiValidator extends Validator
     public function validateZenkaku(string $attribute, $value, array $parameters): bool
     {
         $regex = '/(?:\xEF\xBD[\xA1-\xBF]|\xEF\xBE[\x80-\x9F])|[\x20-\x7E]/';
+
         return !preg_match($regex, $value);
     }
 

--- a/tests/Unit/Validators/ValiiValidatorTest.php
+++ b/tests/Unit/Validators/ValiiValidatorTest.php
@@ -48,6 +48,47 @@ class ValiiValidatorTest extends TestCase
             '全角ひらがな_ja' => ['さんぷる', false],
             '半角ｶﾀｶﾅ' => ['ｻﾝﾌﾟﾙ', false],
             '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['サン プル', false],
+            '全角スペースあり' => ['サン　プル', false],
+        ];
+    }
+
+    /**
+     * 全角カタカナのテスト_スペースあり
+     *
+     * @dataProvider providerKatakanaWithSpaces
+     * @param string $katakana
+     * @param bool $expect
+     */
+    public function test_全角カタカナ_スペースあり($katakana, $expect)
+    {
+        $validator = Validator::make(
+            [
+                'name' => $katakana,
+            ],
+            [
+                'name' => 'katakana:allow_spaces',
+            ]
+        );
+
+        $this->assertEquals($expect, $validator->passes());
+    }
+
+    /**
+     * テストデータ
+     *
+     * @return array
+     */
+    public function providerKatakanaWithSpaces(): array
+    {
+        return [
+            '全角カタカナ' => ['サンプル', true],
+            '全角ひらがな_en' => ['さんぷる', false],
+            '全角ひらがな_ja' => ['さんぷる', false],
+            '半角ｶﾀｶﾅ' => ['ｻﾝﾌﾟﾙ', false],
+            '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['サン プル', true],
+            '全角スペースあり' => ['サン　プル', true],
         ];
     }
 
@@ -124,7 +165,47 @@ class ValiiValidatorTest extends TestCase
             '半角ｶﾀｶﾅのみ' => ['ｻﾝﾌﾟﾙ', true],
             '全角カタカナのみ' => ['サンプル', false],
             '全角半角カタカナ' => ['サンﾌﾟﾙ', false],
-            '半角英数' => ['abcd1234', false]
+            '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['ｻﾝ ﾌﾟﾙ', false],
+            '全角スペースあり' => ['ｻﾝ　ﾌﾟﾙ', false],
+        ];
+    }
+
+    /**
+     * 半角ｶﾀｶﾅのテスト_スペースあり
+     *
+     * @dataProvider providerHankakuKatakanaWithSpaces
+     * @param $katakana string テストデータ
+     * @param bool $expect
+     */
+    public function test_半角ｶﾀｶﾅ_スペースあり($katakana, $expect)
+    {
+        $validator = Validator::make(
+            [
+                'name' => $katakana,
+            ],
+            [
+                'name' => 'hankaku_katakana:allow_spaces',
+            ]
+        );
+
+        $this->assertEquals($expect, $validator->passes());
+    }
+
+    /**
+     * テストデータ
+     *
+     * @return array
+     */
+    public function providerHankakuKatakanaWithSpaces(): array
+    {
+        return [
+            '半角ｶﾀｶﾅのみ' => ['ｻﾝﾌﾟﾙ', true],
+            '全角カタカナのみ' => ['サンプル', false],
+            '全角半角カタカナ' => ['サンﾌﾟﾙ', false],
+            '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['ｻﾝ ﾌﾟﾙ', true],
+            '全角スペースあり' => ['ｻﾝ　ﾌﾟﾙ', false],
         ];
     }
 
@@ -201,7 +282,47 @@ class ValiiValidatorTest extends TestCase
             'ひらがなのみ' => ['さんぷる', true],
             'ひらがな以外' => ['ダミー情報', false],
             'ひらがな以外混じり' => ['さんぷる情報', false],
-            '半角英数' => ['abcd1234', false]
+            '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['さん ぷる', false],
+            '全角スペースあり' => ['さん　ぷる', false],
+        ];
+    }
+
+    /**
+     * ひらがなのテスト_スペースあり
+     *
+     * @dataProvider providerHiraganaWithSpaces
+     * @param $hiragana string テストデータ
+     * @param bool $expect
+     */
+    public function test_ひらがな_スペースあり($hiragana, $expect)
+    {
+        $validator = Validator::make(
+            [
+                'name' => $hiragana,
+            ],
+            [
+                'name' => 'hiragana:allow_spaces',
+            ]
+        );
+
+        $this->assertEquals($expect, $validator->passes());
+    }
+
+    /**
+     * テストデータ
+     *
+     * @return array
+     */
+    public function providerHiraganaWithSpaces(): array
+    {
+        return [
+            'ひらがなのみ' => ['さんぷる', true],
+            'ひらがな以外' => ['ダミー情報', false],
+            'ひらがな以外混じり' => ['さんぷる情報', false],
+            '半角英数' => ['abcd1234', false],
+            '半角スペースあり' => ['さん ぷる', true],
+            '全角スペースあり' => ['さん　ぷる', true],
         ];
     }
 


### PR DESCRIPTION
Add allow spaces mode in Katakana, HankakuKatakana, Hiragana.

- katakana:allow_spaces
  - zenkaku_space : ok
  - hannkaku_space : ok

- hankaku_katakana:allow_spaces
  - zenkaku_space : ng
  - hannkaku_space : ok

- hiragana_katakana:allow_spaces
  - zenkaku_space : ok
  - hannkaku_space : ok