### PR TITLE
Support PHP8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 
 executors:
+  php8_0:
+    docker:
+      - image: circleci/php:8.0
   php7_4:
     docker:
       - image: circleci/php:7.4
@@ -9,7 +12,7 @@ executors:
       - image: circleci/php:7.3
   php7_2:
     docker:
-      - image: circleci/php:7.2
+      - image: circleci/php:7.2.33
   php7_1:
     docker:
       - image: circleci/php:7.1
@@ -35,6 +38,10 @@ commands:
           file: ./coverage.xml
 
 jobs:
+  php80:
+    executor: php8_0
+    steps:
+      - composer_install
   php74:
     executor: php7_4
     steps:
@@ -55,6 +62,7 @@ jobs:
 workflows:
   test:
     jobs:
+      - php80
       - php74
       - php73
       - php72

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "fusic/valii",
     "description": "",
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8.0.0",
         "illuminate/validation": "~5.8|^6.0|^7.0|^8.0",
         "illuminate/translation": "~5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
-        "orchestra/testbench": "^3.5"
+        "phpunit/phpunit": "^7.5|^9.0",
+        "orchestra/testbench": "^3.5|^6.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- support PHP8.0
   - update `phpunit/phpunit` to `^9.0`
   - update `orchestra/testbench` to `^6.9`
- add PHP8.0 workflow pattern to CircleCI config