### PR TITLE
Support Laravel9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ commands:
     steps:
       - checkout
       - run: php -v
+      - run: echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
       - run: sudo composer self-update
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ commands:
     steps:
       - checkout
       - run: php -v
+      - run: composer self-update
       - restore_cache:
           keys:
             - composer-v1-{{ checksum "composer.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - checkout
       - run: php -v
-      - run: composer self-update
+      - run: sudo composer self-update
       - restore_cache:
           keys:
             - composer-v1-{{ checksum "composer.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - checkout
       - run: php -v
-      - run: echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+      - run: sudo echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
       - run: sudo composer self-update
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     steps:
       - checkout
       - run: php -v
-      - run: sudo echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
+      - run: echo 'memory_limit = -1' | sudo tee -a /usr/local/etc/php/conf.d/docker-php-memlimit.ini
       - run: sudo composer self-update
       - restore_cache:
           keys:

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "",
     "require": {
         "php": "^7.1.3|^8.0.0",
-        "illuminate/validation": "~5.8|^6.0|^7.0|^8.0",
-        "illuminate/translation": "~5.8|^6.0|^7.0|^8.0"
+        "illuminate/validation": "~5.8|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/translation": "~5.8|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^9.0",
-        "orchestra/testbench": "^3.5|^6.9"
+        "orchestra/testbench": "^3.5|^6.9|^7.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Supported the following versions required by Laravel9.
- `illuminate/validation` v9
- `illuminate/translation` v9
- `orchestra/testbench` v7.5